### PR TITLE
Various CI Fixes

### DIFF
--- a/.github/actions/install-linux-build-deps/action.yml
+++ b/.github/actions/install-linux-build-deps/action.yml
@@ -9,12 +9,6 @@ runs:
         sudo apt-get update
       shell: bash
 
-    - name: apt-get install clang 
-      run: |
-        sudo apt-get install -y clang-7 --allow-unauthenticated
-        clang-7 --version
-      shell: bash
-      
     - name: apt-get install ssl libs
       run: |
         sudo apt-get install -y openssl --allow-unauthenticated

--- a/.github/actions/yarn-install-and-build/action.yml
+++ b/.github/actions/yarn-install-and-build/action.yml
@@ -23,7 +23,7 @@ runs:
         yarn install
         echo 'Build SDK: yarn build'
         yarn build
-      working-directory: ./js
+      working-directory: ./packages/sdk
       shell: bash
 
     - name: Install modules

--- a/.github/actions/yarn-install-and-verify/action.yml
+++ b/.github/actions/yarn-install-and-verify/action.yml
@@ -27,7 +27,7 @@ runs:
         yarn install
         echo 'Build SDK: yarn build'
         yarn build
-      working-directory: ./js
+      working-directory: ./packages/sdk
       shell: bash
 
     ##############

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,22 +7,6 @@ on:
 name: Rust Checks
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - run: sudo apt install libudev-dev
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path program/Cargo.toml
-
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/.github/workflows/program-test.yml
+++ b/.github/workflows/program-test.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLANA_VERSION: 1.10.9
+  SOLANA_VERSION: 1.14.13
   RUST_TOOLCHAIN: stable
 
 jobs:
@@ -49,4 +49,4 @@ jobs:
         run: |
           cargo +${{ env.RUST_TOOLCHAIN }} test -- --nocapture --test-threads 1
           cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --version
-          cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --bpf-out-dir ../../target/deploy/ -- --nocapture --test-threads 1
+          cargo +${{ env.RUST_TOOLCHAIN }} test-bpf --bpf-out-dir target/deploy/ -- --nocapture --test-threads 1

--- a/.github/workflows/program-test.yml
+++ b/.github/workflows/program-test.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
+      # Build program to create target folder.
+      - uses: ./.github/actions/build-program
+
       # Restore Cache from previous build/test
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -15,5 +15,5 @@ jobs:
       - uses: ./.github/actions/yarn-install-and-verify
         with: 
           cache_id: sdk
-          working_dir: ./js
+          working_dir: ./packages/sdk
           skip_test: true


### PR DESCRIPTION
* Remove `clang-7` dependency as it causes CI to fail and isn't needed
* Change working directories from `./js` to `./packages/sdk` to match template folder structure
* Bump Solana build version to latest
* Set program test bpf-out-dir to `program/target/deploy`
* Build before test to create target dir 
* Removes the redundant `cargo check` job in CI.yml because Clippy is a superset of cargo check